### PR TITLE
ignore `.python-version`?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.


### PR DESCRIPTION
No idea if we should ignore `.python-version`, but IIRC we agreed that the python version did not matter, as long as all dependencies are resolvable through poetry.

Close this PR if this is not desirable.